### PR TITLE
Riktig type for setState, hindret npm run build

### DIFF
--- a/src/components/games/PINSpill/EnterPIN/InputField.tsx
+++ b/src/components/games/PINSpill/EnterPIN/InputField.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useEffect } from "react"
+import { useEffect } from "react"
 
 interface InputFieldProps {
   data: string
@@ -9,7 +9,7 @@ interface InputFieldProps {
   answer: string
   validator: (input: string, answer: string) => boolean
   success: boolean
-  successHook: Dispatch<React.SetStateAction<boolean>>
+  successHook: (success: boolean) => void
   inputRef: React.RefObject<HTMLInputElement>
 }
 

--- a/src/components/games/PINSpill/ShowPIN/Countdown.tsx
+++ b/src/components/games/PINSpill/ShowPIN/Countdown.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 interface CounterProps {
   timeGiven: number
-  setDone: Dispatch<React.SetStateAction<boolean>>
+  setDone: (done: boolean) => void
 }
 
 export const Countdown = ({timeGiven, setDone}: CounterProps) => {


### PR DESCRIPTION
Forenkler typesignatur til `setState` når den blir sendt som prop til komponent. Slik det opprinnelig var, med `Dispatch` førte til feil under `npm run build`. 